### PR TITLE
Group features

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,20 @@ resource "ad_computer_to_ou" "bar" {
 resource "ad_group_to_ou" "baz" {
   ou_distinguished_name        = "${var.ad_ou_dn}"
   group_name                   = "terraformGroupSample"
+  
+  # optional group params
   description                  = "terraform sample group to OU"
+  managed_by                   = ""  # Expects DN format
+  member                       = ""  # Can add a single member in DN format
+
+  group_scope                  = "global"
+  # accepts [global, universal, domain_local] global set by default
+
+  # option parameters for distribution groups
+  distribution_group           = false
+  mail_address                 = ""
+  mail_nickname                = ""
+
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ resource "ad_group_to_ou" "baz" {
   group_scope                  = "global"
   # accepts [global, universal, domain_local] global set by default
 
-  # option parameters for distribution groups
+  # optional parameters for distribution groups
   distribution_group           = false
   mail_address                 = ""
   mail_nickname                = ""

--- a/ad/active_directory_group_helper.go
+++ b/ad/active_directory_group_helper.go
@@ -2,10 +2,18 @@ package ad
 
 import ldap "gopkg.in/ldap.v2"
 
-func addGroupToAD(groupName string, dnName string, adConn *ldap.Conn, desc string) error {
+func addGroupToAD(groupName string, dnName string, groupType string,
+	mailAddress string, mailNickname string, member string,
+	managedBy string, adConn *ldap.Conn, desc string) error {
+
 	addRequest := ldap.NewAddRequest(dnName)
 	addRequest.Attribute("objectClass", []string{"group"})
 	addRequest.Attribute("sAMAccountName", []string{groupName})
+	addRequest.Attribute("groupType", []string{groupType})
+	addRequest.Attribute("mail", []string{mailAddress})
+	addRequest.Attribute("mailNickname", []string{mailNickname})
+	addRequest.Attribute("member", []string{member})
+	addRequest.Attribute("managedBy", []string{managedBy})
 	if desc != "" {
 		addRequest.Attribute("description", []string{desc})
 	}


### PR DESCRIPTION
Needed to expand group creation functionality to enable things like email distribution groups and specifying group scope or group management.

- Added parameter for enabling setting of Group Type (Distibution vs. Security)
- Added parameter for setting group scope (universal, global, domain_local)
- Added parameters for mail attributes (mail and mailNickname)
- Added parameter for adding a group member.  Currently only accepts a single member.
- Added parameter for setting managedBy attribute
