### PR TITLE
add dollar sign ($) at the end of sAMAccountName

### DIFF
--- a/ad/active_directory_computer_helper.go
+++ b/ad/active_directory_computer_helper.go
@@ -5,7 +5,8 @@ import ldap "gopkg.in/ldap.v2"
 func addComputerToAD(computerName string, dnName string, adConn *ldap.Conn, desc string) error {
 	addRequest := ldap.NewAddRequest(dnName)
 	addRequest.Attribute("objectClass", []string{"computer"})
-	addRequest.Attribute("sAMAccountName", []string{computerName})
+	addRequest.Attribute("name", []string{computerName})
+	addRequest.Attribute("sAMAccountName", []string{computerName + "$"})
 	addRequest.Attribute("userAccountControl", []string{"4096"})
 	if desc != "" {
 		addRequest.Attribute("description", []string{desc})


### PR DESCRIPTION
Seems to be that sAMAccountName requires a dollar sign at end appended to flag the object as a computer. 

We encountered problems with duplicate records in AD using this provider. Determined this to be the cause.