### PR TITLE
Connect via LDAP URL which also allow connecting with LDAPS

### DIFF
--- a/ad/config.go
+++ b/ad/config.go
@@ -22,11 +22,12 @@ func (c *Config) Client() (*ldap.Conn, error) {
 	username = c.Username + "@" + c.Domain
 
 	// stay downwards compatible
-	if c.IP != "" {
-		url = fmt.Sprintf("ldap://%s:389", c.IP)
-	} else if c.URL != "" {
+	switch {
+	case c.URL != "":
 		url = c.URL
-	} else {
+	case c.IP != "":
+		url = fmt.Sprintf("ldap://%s:389", c.IP)
+	default:
 		return nil, fmt.Errorf("Need either an IP or LDAP URL to connect to AD, check provider configuration")
 	}
 

--- a/ad/config.go
+++ b/ad/config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	Domain   string
 	IP       string
+	URL      string
 	Username string
 	Password string
 }
@@ -17,8 +18,19 @@ type Config struct {
 // Client() returns a connection for accessing AD services.
 func (c *Config) Client() (*ldap.Conn, error) {
 	var username string
+	var url string
 	username = c.Username + "@" + c.Domain
-	adConn, err := clientConnect(c.IP, username, c.Password)
+
+	// stay downwards compatible
+	if c.IP != "" {
+		url = fmt.Sprintf("ldap://%s:389", c.IP)
+	} else if c.URL != "" {
+		url = c.URL
+	} else {
+		return nil, fmt.Errorf("Need either an IP or LDAP URL to connect to AD, check provider configuration")
+	}
+
+	adConn, err := clientConnect(url, username, c.Password)
 
 	if err != nil {
 		return nil, fmt.Errorf("Error while trying to connect active directory server, Check server IP address, username or password: %s", err)
@@ -27,8 +39,8 @@ func (c *Config) Client() (*ldap.Conn, error) {
 	return adConn, nil
 }
 
-func clientConnect(ip, username, password string) (*ldap.Conn, error) {
-	adConn, err := ldap.Dial("tcp", fmt.Sprintf("%s:%d", ip, 389))
+func clientConnect(url, username, password string) (*ldap.Conn, error) {
+	adConn, err := ldap.DialURL(url)
 	if err != nil {
 		return nil, err
 	}

--- a/ad/provider.go
+++ b/ad/provider.go
@@ -20,9 +20,16 @@ func Provider() terraform.ResourceProvider {
 
 			"ip": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "The IP of the AD Server",
 				DefaultFunc: schema.EnvDefaultFunc("AD_IP", nil),
+			},
+
+			"url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The LDAP URL of the AD Server",
+				DefaultFunc: schema.EnvDefaultFunc("AD_URL", nil),
 			},
 
 			"user": {
@@ -58,6 +65,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
 		Domain:   d.Get("domain").(string),
 		IP:       d.Get("ip").(string),
+		URL:      d.Get("url").(string),
 		Username: d.Get("user").(string),
 		Password: d.Get("password").(string),
 	}

--- a/ad/provider_test.go
+++ b/ad/provider_test.go
@@ -1,10 +1,11 @@
 package ad
 
 import (
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/terraform"
 	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
@@ -33,7 +34,9 @@ func testAccPreCheck(t *testing.T) {
 	}
 
 	if v := os.Getenv("AD_IP"); v == "" {
-		t.Fatal("AD_IP must be set for acceptance tests")
+		if v := os.Getenv("AD_URL"); v == "" {
+			t.Fatal("AD_IP or AD_URL must be set for acceptance tests")
+		}
 	}
 
 	if v := os.Getenv("AD_USER"); v == "" {

--- a/ad/resource_active_directory_add_to_group_test.go
+++ b/ad/resource_active_directory_add_to_group_test.go
@@ -116,6 +116,7 @@ func testAccResourceAddToGroupConfig() string {
 provider "ad" {
   domain   = "%s"
   ip       = "%s"
+  url      = "%s"
   user     = "%s"
   password = "%s"  
 }
@@ -136,6 +137,7 @@ resource "ad_add_to_group" "test" {
 }`,
 		os.Getenv("AD_DOMAIN"),
 		os.Getenv("AD_IP"),
+		os.Getenv("AD_URL"),
 		os.Getenv("AD_USER"),
 		os.Getenv("AD_PASSWORD"),
 		os.Getenv("AD_GROUP_OU_DISTINGUISHED_NAME"))

--- a/ad/resource_active_directory_computer_test.go
+++ b/ad/resource_active_directory_computer_test.go
@@ -125,6 +125,7 @@ func testAccResourceAdComputerConfig() string {
 provider "ad" {
   domain   = "%s"
   ip       = "%s"
+  url      = "%s"
   user     = "%s"
   password = "%s"
 }
@@ -135,6 +136,7 @@ resource "ad_computer" "test" {
 }`,
 		os.Getenv("AD_DOMAIN"),
 		os.Getenv("AD_IP"),
+		os.Getenv("AD_URL"),
 		os.Getenv("AD_USER"),
 		os.Getenv("AD_PASSWORD"),
 		os.Getenv("AD_COMPUTER_DOMAIN"))

--- a/ad/resource_active_directory_computer_to_ou_test.go
+++ b/ad/resource_active_directory_computer_to_ou_test.go
@@ -109,7 +109,8 @@ func testAccResourceAdComputerToOUConfig() string {
 	return fmt.Sprintf(`
 provider "ad" {
   domain   = "%s"
-  ip       = "%s"
+	ip       = "%s"
+	url      = "%s"
   user     = "%s"
   password = "%s"  
 }
@@ -121,6 +122,7 @@ resource "ad_computer_to_ou" "test" {
 }`,
 		os.Getenv("AD_DOMAIN"),
 		os.Getenv("AD_IP"),
+		os.Getenv("AD_URL"),
 		os.Getenv("AD_USER"),
 		os.Getenv("AD_PASSWORD"),
 		os.Getenv("AD_COMPUTER_OU_DISTINGUISHED_NAME"))

--- a/ad/resource_active_directory_group_to_ou_test.go
+++ b/ad/resource_active_directory_group_to_ou_test.go
@@ -131,7 +131,8 @@ func testAccResourceAdGroupToOUConfig() string {
 	return fmt.Sprintf(`
 provider "ad" {
   domain   = "%s"
-  ip       = "%s"
+	ip       = "%s"
+	url      = "%s"
   user     = "%s"
   password = "%s"  
 }
@@ -144,6 +145,7 @@ resource "ad_group_to_ou" "test" {
 }`,
 		os.Getenv("AD_DOMAIN"),
 		os.Getenv("AD_IP"),
+		os.Getenv("AD_URL"),
 		os.Getenv("AD_USER"),
 		os.Getenv("AD_PASSWORD"),
 		os.Getenv("AD_GROUP_OU_DISTINGUISHED_NAME"))
@@ -153,7 +155,8 @@ func testAccResourceAdGroupToOUConfig_with_auto_gid() string {
 	return fmt.Sprintf(`
 provider "ad" {
   domain   = "%s"
-  ip       = "%s"
+	ip       = "%s"
+	url      = "%s"
   user     = "%s"
   password = "%s"  
 }
@@ -175,6 +178,7 @@ resource "ad_group_to_ou" "test" {
 }`,
 		os.Getenv("AD_DOMAIN"),
 		os.Getenv("AD_IP"),
+		os.Getenv("AD_URL"),
 		os.Getenv("AD_USER"),
 		os.Getenv("AD_PASSWORD"),
 		os.Getenv("AD_GROUP_OU_DISTINGUISHED_NAME"))

--- a/ad/resource_active_directory_user_test.go
+++ b/ad/resource_active_directory_user_test.go
@@ -26,7 +26,7 @@ func TestAccAdUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAdUserExists("ad_user.test"),
 					resource.TestCheckResourceAttr(
-						"ad_user.test", "logon_name", "terraform"),
+						"ad_user.test", "logon_name", "test"),
 				),
 			},
 		},
@@ -126,18 +126,20 @@ func testAccResourceAdUserConfig() string {
 provider "ad" {
   domain   = "%s"
   ip       = "%s"
+  url      = "%s"
   user     = "%s"
   password = "%s"
 }
 resource "ad_user" "test" {
   domain = "%s"
   first_name = "first"
-  last_name = " last"
+  last_name = "last"
   logon_name = "test"
   password = "testpassword"
 }`,
 		os.Getenv("AD_DOMAIN"),
 		os.Getenv("AD_IP"),
+		os.Getenv("AD_URL"),
 		os.Getenv("AD_USER"),
 		os.Getenv("AD_PASSWORD"),
 		os.Getenv("AD_USER_DOMAIN"))

--- a/tf-ad-devrc.mk.example
+++ b/tf-ad-devrc.mk.example
@@ -12,7 +12,6 @@
 # else make will add the whitespace to the variable as well.
 #
 # The essentials. None of the tests will run if you don't have these.
-# export AD_IP     ?= server.ip
 export AD_URL      ?= server.url
 export AD_DOMAIN   ?= server.domain
 export AD_USER     ?= server.user

--- a/tf-ad-devrc.mk.example
+++ b/tf-ad-devrc.mk.example
@@ -12,7 +12,8 @@
 # else make will add the whitespace to the variable as well.
 #
 # The essentials. None of the tests will run if you don't have these.
-export AD_IP   ?= server.ip
+# export AD_IP     ?= server.ip
+export AD_URL      ?= server.url
 export AD_DOMAIN   ?= server.domain
 export AD_USER     ?= server.user
 export AD_PASSWORD ?= changeme


### PR DESCRIPTION
The proposed changes allow to connect to the AD by LDAP URL, which allows the use of encrypted connections via LDAPS.

The change is downwards compatible: If only AD_IP is defined, a valid LDAP URL is generated with the IP and port 389.